### PR TITLE
Fix hardcoded paths in processing scripts

### DIFF
--- a/scripts/clean_title_periods.py
+++ b/scripts/clean_title_periods.py
@@ -7,17 +7,19 @@ Dropdown titles shouldn't have periods.
 import json
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 def clean_title_periods():
     """Remove trailing periods from all English titles."""
     
     # Files to update
     files_to_update = [
-        "/Users/jneumann/Repos/cleros/web/public/orphic_hymns_sentences.json",
-        "/Users/jneumann/Repos/cleros/web/public/orphic_hymns_parallel.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns_parallel.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/chunked/orphic_hymns_sentences.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns.json"
+        str(REPO_ROOT / "web" / "public" / "orphic_hymns_sentences.json"),
+        str(REPO_ROOT / "web" / "public" / "orphic_hymns_parallel.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "orphic_hymns_parallel.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "chunked" / "orphic_hymns_sentences.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "orphic_hymns.json"),
     ]
     
     for file_path in files_to_update:

--- a/scripts/collect_additional_oracle_queries.py
+++ b/scripts/collect_additional_oracle_queries.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional
 import time
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 # Target databases and their search patterns
 SEARCH_TARGETS = {
     "papyri_info_base": "https://papyri.info/search",
@@ -284,7 +286,7 @@ def main():
     candidates = create_manual_candidate_list()
     
     # Save to file
-    output_file = "/Users/jneumann/Repos/cleros/data/sources/oracle_query_expansion_candidates.json"
+    output_file = str(REPO_ROOT / "data" / "sources" / "oracle_query_expansion_candidates.json")
     save_candidate_list(candidates, output_file)
     
     # Print summary

--- a/scripts/convert_papyrus_oracle_queries.py
+++ b/scripts/convert_papyrus_oracle_queries.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 def categorize_query(question_summary: str, notes: str) -> str:
     """Categorize query based on content summary."""
@@ -185,8 +187,8 @@ def main():
     """Main function to convert CSV to JSON."""
     
     # Input and output files
-    csv_file = "/Users/jneumann/Repos/cleros/oracle_queries_pack_v0.4 (1).csv"
-    output_file = "/Users/jneumann/Repos/cleros/data/sources/papyrus_oracle_queries_raw.json"
+    csv_file = str(REPO_ROOT / "oracle_queries_pack_v0.4 (1).csv")
+    output_file = str(REPO_ROOT / "data" / "sources" / "papyrus_oracle_queries_raw.json")
     
     print("🏺 CONVERTING PAPYRUS ORACLE QUERIES")
     print("=" * 50)

--- a/scripts/create_combined_stopwords.py
+++ b/scripts/create_combined_stopwords.py
@@ -8,6 +8,8 @@ import json
 from pathlib import Path
 from typing import Set
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 def load_stopwords_from_json(file_path: Path) -> Set[str]:
     """Load stop words from a JSON file."""
     try:
@@ -20,7 +22,7 @@ def load_stopwords_from_json(file_path: Path) -> Set[str]:
 
 def main():
     """Combine and deduplicate stop words from all sources."""
-    base_path = Path("/Users/jneumann/Repos/english-word-atlas/data/sources/STOP")
+    base_path = REPO_ROOT.parent / "english-word-atlas" / "data" / "sources" / "STOP"
     
     # Load all stop word files
     stop_files = {
@@ -59,7 +61,7 @@ def main():
     print(f"Source breakdown: {source_counts}")
     
     # Save to cleros project
-    output_path = Path("/Users/jneumann/Repos/cleros/data/combined_stopwords.json")
+    output_path = REPO_ROOT / "data" / "combined_stopwords.json"
     output_path.parent.mkdir(exist_ok=True)
     
     # Create metadata
@@ -77,7 +79,7 @@ def main():
     print(f"\nSaved combined stop words to: {output_path}")
     
     # Also save just the list for easy loading
-    simple_output_path = Path("/Users/jneumann/Repos/cleros/data/stopwords_simple.json")
+    simple_output_path = REPO_ROOT / "data" / "stopwords_simple.json"
     with open(simple_output_path, 'w', encoding='utf-8') as f:
         json.dump(sorted_stopwords, f, indent=2, ensure_ascii=False)
     

--- a/scripts/create_papyrus_oracle_parallel.py
+++ b/scripts/create_papyrus_oracle_parallel.py
@@ -8,11 +8,13 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 def create_papyrus_oracle_parallel():
     """Convert papyrus oracle queries to parallel format following established paradigm."""
     
     # Load gold standard data
-    source_file = Path("/Users/jneumann/Repos/cleros/data/gold_standard/papyrus_oracle_queries.json")
+    source_file = REPO_ROOT / "data" / "gold_standard" / "papyrus_oracle_queries.json"
     with open(source_file, 'r', encoding='utf-8') as f:
         gold_standard = json.load(f)
     
@@ -51,12 +53,12 @@ def create_papyrus_oracle_parallel():
     
     # Save to both locations following the paradigm
     # 1. Gold standard location
-    gs_output = Path("/Users/jneumann/Repos/cleros/data/gold_standard/papyrus_oracle_queries_parallel.json")
+    gs_output = REPO_ROOT / "data" / "gold_standard" / "papyrus_oracle_queries_parallel.json"
     with open(gs_output, 'w', encoding='utf-8') as f:
         json.dump(parallel_data, f, indent=2, ensure_ascii=False)
     
     # 2. Web public location  
-    web_output = Path("/Users/jneumann/Repos/cleros/web/public/papyrus_oracle_queries_parallel.json")
+    web_output = REPO_ROOT / "web" / "public" / "papyrus_oracle_queries_parallel.json"
     with open(web_output, 'w', encoding='utf-8') as f:
         json.dump(parallel_data, f, indent=2, ensure_ascii=False)
     

--- a/scripts/create_papyrus_oracle_structured.py
+++ b/scripts/create_papyrus_oracle_structured.py
@@ -8,11 +8,13 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 def create_papyrus_oracle_structured():
     """Convert papyrus oracle queries to structured format for web interface."""
     
     # Load original data
-    source_file = Path("/Users/jneumann/Repos/cleros/web/public/papyrus_oracle_queries.json")
+    source_file = REPO_ROOT / "web" / "public" / "papyrus_oracle_queries.json"
     with open(source_file, 'r', encoding='utf-8') as f:
         original_data = json.load(f)
     
@@ -70,7 +72,7 @@ def create_papyrus_oracle_structured():
         structured_data["sections"].append(section)
     
     # Write structured file
-    output_file = Path("/Users/jneumann/Repos/cleros/web/public/papyrus_oracle_queries_structured.json")
+    output_file = REPO_ROOT / "web" / "public" / "papyrus_oracle_queries_structured.json"
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(structured_data, f, indent=2, ensure_ascii=False)
     

--- a/scripts/create_structured_corpora.py
+++ b/scripts/create_structured_corpora.py
@@ -7,11 +7,13 @@ This replaces the arbitrary line-number divisions with content-based structural 
 import json
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 def create_structured_argonautica():
     """Create Argonautica with 6 natural episodes based on narrative structure."""
     
     # Load the original sentence-chunked data
-    source_file = Path("/Users/jneumann/Repos/cleros/data/gold_standard/chunked/orphic_argonautica_sentences.json")
+    source_file = REPO_ROOT / "data" / "gold_standard" / "chunked" / "orphic_argonautica_sentences.json"
     with open(source_file, 'r', encoding='utf-8') as f:
         original_data = json.load(f)
     
@@ -99,7 +101,7 @@ def create_structured_argonautica():
         structured_data["sections"].append(episode_section)
     
     # Write structured file
-    output_file = Path("/Users/jneumann/Repos/cleros/web/public/orphic_argonautica_episodes.json")
+    output_file = REPO_ROOT / "web" / "public" / "orphic_argonautica_episodes.json"
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(structured_data, f, indent=2, ensure_ascii=False)
     
@@ -110,7 +112,7 @@ def create_structured_lithica():
     """Create Lithica with 4 natural sections based on thematic content."""
     
     # Load the original sentence-chunked data
-    source_file = Path("/Users/jneumann/Repos/cleros/data/gold_standard/chunked/orphic_lithica_sentences.json")
+    source_file = REPO_ROOT / "data" / "gold_standard" / "chunked" / "orphic_lithica_sentences.json"
     with open(source_file, 'r', encoding='utf-8') as f:
         original_data = json.load(f)
     
@@ -186,7 +188,7 @@ def create_structured_lithica():
         structured_data["sections"].append(section_data)
     
     # Write structured file
-    output_file = Path("/Users/jneumann/Repos/cleros/web/public/orphic_lithica_sections.json")
+    output_file = REPO_ROOT / "web" / "public" / "orphic_lithica_sections.json"
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(structured_data, f, indent=2, ensure_ascii=False)
     

--- a/scripts/download_nltk_stopwords.py
+++ b/scripts/download_nltk_stopwords.py
@@ -8,6 +8,8 @@ import json
 import nltk
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 def download_nltk_stopwords():
     """Download NLTK stop words and save to our data directory."""
     try:
@@ -28,7 +30,7 @@ def download_nltk_stopwords():
         print(f"Contains 'of': {'of' in english_stopwords}")
         
         # Save to our data directory
-        output_path = Path("/Users/jneumann/Repos/cleros/data/nltk_stopwords.json")
+        output_path = REPO_ROOT / "data" / "nltk_stopwords.json"
         with open(output_path, 'w', encoding='utf-8') as f:
             json.dump(sorted(english_stopwords), f, indent=2, ensure_ascii=False)
         

--- a/scripts/fix_incense_mapping.py
+++ b/scripts/fix_incense_mapping.py
@@ -5,16 +5,18 @@ Fix incense data mapping using section indexes instead of title matching
 import json
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 def fix_incense_mapping():
     """Update corpus with incense data using section indexes."""
-    
+
     # Load original sentences file (source of incense data)
-    sentences_file = Path("/Users/jneumann/Repos/cleros/web/public/orphic_hymns_sentences.json")
+    sentences_file = REPO_ROOT / "web" / "public" / "orphic_hymns_sentences.json"
     with open(sentences_file, 'r', encoding='utf-8') as f:
         sentences_data = json.load(f)
     
     # Load corpus file (target for incense data)
-    corpus_file = Path("/Users/jneumann/Repos/cleros/web/public/corpus_20250822_121628/hymns.json")
+    corpus_file = REPO_ROOT / "web" / "public" / "corpus_20250822_121628" / "hymns.json"
     with open(corpus_file, 'r', encoding='utf-8') as f:
         corpus_data = json.load(f)
     

--- a/scripts/fix_title_edge_cases.py
+++ b/scripts/fix_title_edge_cases.py
@@ -8,6 +8,8 @@ Fix edge cases in hymn title translations:
 import json
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 def fix_title_edge_cases():
     """Fix specific title edge cases that got mangled."""
@@ -35,11 +37,11 @@ def fix_title_edge_cases():
     
     # Files to update
     files_to_update = [
-        "/Users/jneumann/Repos/cleros/web/public/orphic_hymns_sentences.json",
-        "/Users/jneumann/Repos/cleros/web/public/orphic_hymns_parallel.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns_parallel.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/chunked/orphic_hymns_sentences.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns.json"
+        str(REPO_ROOT / "web" / "public" / "orphic_hymns_sentences.json"),
+        str(REPO_ROOT / "web" / "public" / "orphic_hymns_parallel.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "orphic_hymns_parallel.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "chunked" / "orphic_hymns_sentences.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "orphic_hymns.json"),
     ]
     
     for file_path in files_to_update:

--- a/scripts/generate_line_embeddings.py
+++ b/scripts/generate_line_embeddings.py
@@ -18,8 +18,9 @@ logger = logging.getLogger(__name__)
 class LineEmbeddingGenerator:
     """Generates embeddings for individual lines of text."""
     
-    def __init__(self, base_path: str = "/Users/jneumann/Repos/cleros"):
-        self.base_path = Path(base_path)
+    def __init__(self, base_path: str = None):
+        REPO_ROOT = Path(__file__).resolve().parent.parent
+        self.base_path = Path(base_path) if base_path else REPO_ROOT
         self.model = SentenceTransformer('all-MiniLM-L6-v2')  # Same model as used for sentences
         
         self.corpus_info = {

--- a/scripts/normalize_hymn_titles.py
+++ b/scripts/normalize_hymn_titles.py
@@ -9,6 +9,8 @@ import json
 import re
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 def normalize_title(title):
     """Normalize a single title for UI consistency."""
@@ -53,11 +55,11 @@ def update_corpus_files():
     
     # Files to update
     files_to_update = [
-        "/Users/jneumann/Repos/cleros/web/public/orphic_hymns_sentences.json",
-        "/Users/jneumann/Repos/cleros/web/public/orphic_hymns_parallel.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns_parallel.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/chunked/orphic_hymns_sentences.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns.json"
+        str(REPO_ROOT / "web" / "public" / "orphic_hymns_sentences.json"),
+        str(REPO_ROOT / "web" / "public" / "orphic_hymns_parallel.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "orphic_hymns_parallel.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "chunked" / "orphic_hymns_sentences.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "orphic_hymns.json"),
     ]
     
     for file_path in files_to_update:

--- a/scripts/oracle_keyword_extractor.py
+++ b/scripts/oracle_keyword_extractor.py
@@ -19,16 +19,17 @@ logger = logging.getLogger(__name__)
 class OracleKeywordExtractor:
     """Extracts meaningful keywords from queries for oracle response highlighting."""
     
-    def __init__(self, base_path: str = "/Users/jneumann/Repos"):
-        self.base_path = Path(base_path)
+    def __init__(self, base_path: str = None):
+        REPO_ROOT = Path(__file__).resolve().parent.parent
+        self.base_path = Path(base_path) if base_path else REPO_ROOT
         self.stop_words = set()
         self._load_stop_words()
-    
+
     def _load_stop_words(self):
         """Load stop words from the combined stopwords list."""
         try:
             # Use our combined and deduplicated stop words list
-            stopwords_path = self.base_path / "cleros/data/nltk_stopwords.json"
+            stopwords_path = self.base_path / "data" / "nltk_stopwords.json"
             with open(stopwords_path, 'r', encoding='utf-8') as f:
                 stop_words_list = json.load(f)
                 self.stop_words = set(word.lower() for word in stop_words_list)

--- a/scripts/oracle_random_selection.py
+++ b/scripts/oracle_random_selection.py
@@ -27,8 +27,9 @@ logger = logging.getLogger(__name__)
 class OracleRandomSelector:
     """Handles random selection of sentences from the three main Orphic texts."""
     
-    def __init__(self, base_path: str = "/Users/jneumann/Repos/cleros"):
-        self.base_path = Path(base_path)
+    def __init__(self, base_path: str = None):
+        REPO_ROOT = Path(__file__).resolve().parent.parent
+        self.base_path = Path(base_path) if base_path else REPO_ROOT
         self.corpus_info = {
             "hymns": {
                 "name": "Orphic Hymns",
@@ -219,7 +220,8 @@ def main():
         print()
     
     # Save response for inspection
-    output_path = Path("/Users/jneumann/Repos/cleros/test_oracle_response.json")
+    REPO_ROOT = Path(__file__).resolve().parent.parent
+    output_path = REPO_ROOT / "test_oracle_response.json"
     with open(output_path, 'w', encoding='utf-8') as f:
         json.dump(response, f, indent=2, ensure_ascii=False)
     

--- a/scripts/oracle_semantic_scorer.py
+++ b/scripts/oracle_semantic_scorer.py
@@ -19,8 +19,9 @@ logger = logging.getLogger(__name__)
 class OracleSemanticScorer:
     """Scores lines semantically against user queries for oracle highlighting."""
     
-    def __init__(self, base_path: str = "/Users/jneumann/Repos/cleros"):
-        self.base_path = Path(base_path)
+    def __init__(self, base_path: str = None):
+        REPO_ROOT = Path(__file__).resolve().parent.parent
+        self.base_path = Path(base_path) if base_path else REPO_ROOT
         self.model = SentenceTransformer('all-MiniLM-L6-v2')  # Same model as embeddings
         
         # Load line embeddings for all corpora

--- a/scripts/sentence_chunker.py
+++ b/scripts/sentence_chunker.py
@@ -207,7 +207,8 @@ def process_parallel_json(input_file: Path, output_file: Path) -> Dict[str, Any]
 
 def main():
     """Main processing function."""
-    gold_standard_dir = Path('/Users/jneumann/Repos/cleros/data/gold_standard')
+    REPO_ROOT = Path(__file__).resolve().parent.parent
+    gold_standard_dir = REPO_ROOT / "data" / "gold_standard"
     output_dir = gold_standard_dir / 'chunked'
     output_dir.mkdir(exist_ok=True)
     

--- a/scripts/structure_tablets_queries.py
+++ b/scripts/structure_tablets_queries.py
@@ -7,11 +7,13 @@ Converts them to match the expected sections/sentences/line_details format.
 import json
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 def structure_golden_tablets():
     """Convert Golden Tablets to structured format for web interface."""
-    
+
     # Load original data
-    source_file = Path("/Users/jneumann/Repos/cleros/web/public/orphic_golden_tablets.json")
+    source_file = REPO_ROOT / "web" / "public" / "orphic_golden_tablets.json"
     with open(source_file, 'r', encoding='utf-8') as f:
         original_data = json.load(f)
     
@@ -65,7 +67,7 @@ def structure_golden_tablets():
         structured_data["sections"].append(section)
     
     # Write structured file
-    output_file = Path("/Users/jneumann/Repos/cleros/web/public/orphic_golden_tablets_structured.json")
+    output_file = REPO_ROOT / "web" / "public" / "orphic_golden_tablets_structured.json"
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(structured_data, f, indent=2, ensure_ascii=False)
     
@@ -76,7 +78,7 @@ def structure_oracle_queries():
     """Convert Oracle Queries to structured format for web interface."""
     
     # Load original data
-    source_file = Path("/Users/jneumann/Repos/cleros/web/public/dodona_oracle_queries.json")
+    source_file = REPO_ROOT / "web" / "public" / "dodona_oracle_queries.json"
     with open(source_file, 'r', encoding='utf-8') as f:
         original_data = json.load(f)
     
@@ -130,7 +132,7 @@ def structure_oracle_queries():
         structured_data["sections"].append(section)
     
     # Write structured file
-    output_file = Path("/Users/jneumann/Repos/cleros/web/public/dodona_oracle_queries_structured.json")
+    output_file = REPO_ROOT / "web" / "public" / "dodona_oracle_queries_structured.json"
     with open(output_file, 'w', encoding='utf-8') as f:
         json.dump(structured_data, f, indent=2, ensure_ascii=False)
     

--- a/scripts/translate_curated_oracle_batch.py
+++ b/scripts/translate_curated_oracle_batch.py
@@ -10,21 +10,23 @@ from datetime import datetime
 from pathlib import Path
 import sys
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 # Add the orphica directory to the path so we can import chunk_translator
-sys.path.append('/Users/jneumann/Repos/cleros/attic/development_2025-08-21/orphica')
+sys.path.append(str(REPO_ROOT / "attic" / "development_2025-08-21" / "orphica"))
 
 from chunk_translator import ChunkTranslator, TranslatedLine, TranslationChunk
 from dotenv import load_dotenv
 
 # Load environment variables
-load_dotenv(dotenv_path='/Users/jneumann/Repos/cleros/.env')
+load_dotenv(dotenv_path=str(REPO_ROOT / ".env"))
 
 def translate_curated_oracle_batch():
     """Translate the curated papyrus oracle queries using GPT-5 reasoning."""
     
     # Input and output files
-    input_file = "/Users/jneumann/Repos/cleros/data/sources/curated_oracle_queries_batch.json"
-    output_file = "/Users/jneumann/Repos/cleros/data/gold_standard/papyrus_oracle_queries_translated.json"
+    input_file = str(REPO_ROOT / "data" / "sources" / "curated_oracle_queries_batch.json")
+    output_file = str(REPO_ROOT / "data" / "gold_standard" / "papyrus_oracle_queries_translated.json")
     
     print("🏺 GPT-5 CURATED PAPYRUS ORACLE QUERIES TRANSLATION")
     print("=" * 65)

--- a/scripts/translate_hymn_titles.py
+++ b/scripts/translate_hymn_titles.py
@@ -8,16 +8,18 @@ import json
 import sys
 from pathlib import Path
 
-# Add the project root to the path so we can import the chunk translator
-sys.path.insert(0, str(Path(__file__).parent.parent))
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
-sys.path.insert(0, "/Users/jneumann/Repos/cleros/attic/development_2025-08-21/orphica")
+# Add the project root to the path so we can import the chunk translator
+sys.path.insert(0, str(REPO_ROOT))
+
+sys.path.insert(0, str(REPO_ROOT / "attic" / "development_2025-08-21" / "orphica"))
 from chunk_translator import ChunkTranslator, TranslationChunk, TranslatedLine
 
 
 def extract_hymn_titles():
     """Extract all Greek hymn titles from the corpus."""
-    hymns_file = Path("/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns.json")
+    hymns_file = REPO_ROOT / "data" / "gold_standard" / "orphic_hymns.json"
     
     with open(hymns_file, 'r', encoding='utf-8') as f:
         data = json.load(f)
@@ -108,10 +110,10 @@ def update_corpus_files(titles):
     
     # Files to update
     files_to_update = [
-        "/Users/jneumann/Repos/cleros/web/public/orphic_hymns_sentences.json",
-        "/Users/jneumann/Repos/cleros/web/public/orphic_hymns_parallel.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns_parallel.json",
-        "/Users/jneumann/Repos/cleros/data/gold_standard/chunked/orphic_hymns_sentences.json"
+        str(REPO_ROOT / "web" / "public" / "orphic_hymns_sentences.json"),
+        str(REPO_ROOT / "web" / "public" / "orphic_hymns_parallel.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "orphic_hymns_parallel.json"),
+        str(REPO_ROOT / "data" / "gold_standard" / "chunked" / "orphic_hymns_sentences.json"),
     ]
     
     for file_path in files_to_update:
@@ -138,7 +140,7 @@ def update_corpus_files(titles):
             json.dump(data, f, ensure_ascii=False, indent=2)
     
     # Also update the main gold standard file
-    hymns_file = Path("/Users/jneumann/Repos/cleros/data/gold_standard/orphic_hymns.json")
+    hymns_file = REPO_ROOT / "data" / "gold_standard" / "orphic_hymns.json"
     with open(hymns_file, 'r', encoding='utf-8') as f:
         data = json.load(f)
     
@@ -168,7 +170,7 @@ def main():
     print("\nTitle translation complete!")
     
     # Save translation results
-    results_file = Path("/Users/jneumann/Repos/cleros/data/sources/hymn_title_translations.json")
+    results_file = REPO_ROOT / "data" / "sources" / "hymn_title_translations.json"
     with open(results_file, 'w', encoding='utf-8') as f:
         json.dump(translated_titles, f, ensure_ascii=False, indent=2)
     

--- a/scripts/update_corpus_with_incense.py
+++ b/scripts/update_corpus_with_incense.py
@@ -5,16 +5,18 @@ Update corpus files to include incense information from original sentences files
 import json
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 def update_hymns_corpus_with_incense():
     """Update the hymns corpus file to include incense information."""
-    
+
     # Load original sentences file (contains incense data)
-    sentences_file = Path("/Users/jneumann/Repos/cleros/web/public/orphic_hymns_sentences.json")
+    sentences_file = REPO_ROOT / "web" / "public" / "orphic_hymns_sentences.json"
     with open(sentences_file, 'r', encoding='utf-8') as f:
         sentences_data = json.load(f)
     
     # Load corpus file (needs incense data)
-    corpus_file = Path("/Users/jneumann/Repos/cleros/web/public/corpus_20250822_121628/hymns.json")
+    corpus_file = REPO_ROOT / "web" / "public" / "corpus_20250822_121628" / "hymns.json"
     with open(corpus_file, 'r', encoding='utf-8') as f:
         corpus_data = json.load(f)
     


### PR DESCRIPTION
## Summary
- All 20 Python scripts in `scripts/` had hardcoded `/Users/jneumann/Repos/cleros` paths
- Replaced with `REPO_ROOT = Path(__file__).resolve().parent.parent` so scripts work for any contributor from any checkout location
- Zero hardcoded user paths remain (`grep` verified)

## Test plan
- [ ] Verify `grep -r "/Users/" scripts/` returns no results
- [ ] Spot-check a script runs from a different working directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `scripts/` path construction and default `base_path` handling, but could break script execution if any expected files/dirs differ from the repo layout.
> 
> **Overview**
> Standardizes all Python scripts under `scripts/` to be checkout-location agnostic by replacing hardcoded `/Users/...` paths with `REPO_ROOT = Path(__file__).resolve().parent.parent` and repo-relative `Path` joins.
> 
> Also updates several script entrypoints/classes (e.g., embedding generation, oracle selection/scoring/keyword extraction, translators) to default `base_path` to `REPO_ROOT`, fixes stopwords file resolution to `data/nltk_stopwords.json`, and makes output/input paths (including `.env` and `sys.path` additions) relative to the repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 014a869988bce5640b96b3cb40c454eceddf6831. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->